### PR TITLE
Fix bug with months in prod version

### DIFF
--- a/redux/reducers/schedulerReducer.js
+++ b/redux/reducers/schedulerReducer.js
@@ -17,8 +17,11 @@ import {
 } from 'actions/schedulerActions';
 
 // Initial State
+moment.locale('pl');
+const initialActualMonth = moment().format('MMMM[ ]YYYY');
+
 const initialState = {
-  actualMonth: moment().format('MMMM[ ]YYYY'),
+  actualMonth: initialActualMonth,
   monthVisible: true,
   expandedDays: [],
   dialogOpened: false,
@@ -35,6 +38,7 @@ export default function scheduler(state = initialState, action) {
       const newMonth = moment(state.actualMonth, 'MMMM[ ]YYYY')
         .add(action.val, 'months')
         .format('MMMM[ ]YYYY');
+      console.log(newMonth);
       return { ...state, actualMonth: newMonth };
     }
 


### PR DESCRIPTION
### Description
Fixed bug with date. Date was wrong format in scheduler state. 
Added `moment.locale('pl')` before initialization of scheduler state.